### PR TITLE
NTRDMA: fix to use accepted dma immediate data

### DIFF
--- a/drivers/ntc/ntc_ntb_msi.c
+++ b/drivers/ntc/ntc_ntb_msi.c
@@ -1063,17 +1063,17 @@ static int ntc_ntb_req_imm(struct ntc_dev *ntc, void *req,
 	struct ntc_ntb_imm *imm;
 	int rc;
 
-#ifdef CONFIG_NTC_NTB_DMA_REQ_IMM
 	struct dma_chan *chan = req;
 	struct dma_async_tx_descriptor *tx;
 	dma_cookie_t cookie;
 	int flags;
 
-	if (chan->device->device_prep_dma_imm) {
+	if (chan->device->device_prep_dma_imm_data && len == 8) {
 		flags = ntc_ntb_req_prep_flags(ntc, fence);
 
-		tx = chan->device->device_prep_dma_imm(chan, dst, ptr,
-						       len, flags);
+		tx = chan->device->device_prep_dma_imm_data(chan, dst,
+							    *(u64 *)ptr,
+							    flags);
 		if (!tx)
 			return -ENOMEM;
 
@@ -1086,7 +1086,6 @@ static int ntc_ntb_req_imm(struct ntc_dev *ntc, void *req,
 
 		return 0;
 	}
-#endif
 
 	imm = kmalloc_node(sizeof(*imm), GFP_ATOMIC,
 			   dev_to_node(&ntc->dev));


### PR DESCRIPTION
There were differences between interfaces of the earlier patch used by
ntrdma for dma immediate data, and the patch accepted upstream in the
kernel.  Fix ntrdma to use the interface of the accepted patch.

Signed-off-by: Allen Hubbe allenbh@gmail.com
