### PR TITLE
ntrdma: fix bounds on advancing to next vbell

### DIFF
--- a/drivers/infiniband/hw/ntrdma/ntrdma_cq.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_cq.c
@@ -89,6 +89,7 @@ void ntrdma_cq_del(struct ntrdma_cq *cq)
 {
 	struct ntrdma_dev *dev = ntrdma_cq_dev(cq);
 
+	tasklet_disable(&cq->cue_work);
 	spin_lock_bh(&cq->arm_lock);
 	{
 		cq->arm = 0;

--- a/drivers/infiniband/hw/ntrdma/ntrdma_qp.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_qp.c
@@ -843,6 +843,7 @@ void ntrdma_rqp_del(struct ntrdma_rqp *rqp)
 	struct ntrdma_dev *dev = ntrdma_rqp_dev(rqp);
 
 	rqp->state = NTRDMA_QPS_RESET;
+	tasklet_disable(&rqp->send_work);
 	ntrdma_dev_vbell_del(dev, &rqp->send_vbell, rqp->send_vbell_idx);
 
 	ntrdma_rres_del(&rqp->rres);

--- a/drivers/infiniband/hw/ntrdma/ntrdma_vbell.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_vbell.c
@@ -107,7 +107,7 @@ u32 ntrdma_dev_vbell_next(struct ntrdma_dev *dev)
 	{
 		idx = dev->vbell_next;
 
-		if (dev->vbell_count < ++dev->vbell_next)
+		if (dev->vbell_count <= ++dev->vbell_next)
 			dev->vbell_next = dev->vbell_start;
 	}
 	spin_unlock_bh(&dev->vbell_next_lock);


### PR DESCRIPTION
The comparison allowed the next vbell index to advance to be equal to the count, which is an invalid index one past the end of the array. Change the comparison so that the next vbell will wrap back to the start if it is equal to the count.
