### PR TITLE
ntc: fix final sgl page-aligned length

### DIFF
--- a/drivers/ntc/ntc_phys.c
+++ b/drivers/ntc/ntc_phys.c
@@ -130,9 +130,10 @@ static int ntc_phys_umem_sgl(struct ntc_dev *ntc, void *umem,
 		sgl[0].len -= dma_len;
 
 		if (dma_count <= count) {
-			/* dma_len is end offset in the last page */
+			/* dma_len is offset from the end of the last page */
 			dma_len = (dma_len + ibumem->length) & ~PAGE_MASK;
-			sgl[dma_count - 1].len -= PAGE_SIZE - dma_len;
+			dma_len = (PAGE_SIZE - dma_len) & ~PAGE_MASK;
+			sgl[dma_count - 1].len -= dma_len;
 		}
 	}
 

--- a/drivers/ntc/ntc_virt.c
+++ b/drivers/ntc/ntc_virt.c
@@ -113,9 +113,10 @@ static int ntc_virt_umem_sgl(struct ntc_dev *ntc, void *umem,
 		sgl[0].len -= virt_len;
 
 		if (virt_count <= count) {
-			/* virt_len is end offset in the last page */
+			/* virt_len is offset from the end of the last page */
 			virt_len = (virt_len + ibumem->length) & ~PAGE_MASK;
-			sgl[virt_count - 1].len -= PAGE_SIZE - virt_len;
+			virt_len = (PAGE_SIZE - virt_len) & ~PAGE_MASK;
+			sgl[virt_count - 1].len -= virt_len;
 		}
 	}
 


### PR DESCRIPTION
If the final entry in the scatter list ended on a page alignment boundary, the length was truncated to zero.  Instead, in that case we want to subtract zero from the length.
