### PR TITLE
ntrdma: use tasklet_kill for cleanup

### DIFF
--- a/drivers/infiniband/hw/ntrdma/ntrdma_cq.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_cq.c
@@ -89,13 +89,14 @@ void ntrdma_cq_del(struct ntrdma_cq *cq)
 {
 	struct ntrdma_dev *dev = ntrdma_cq_dev(cq);
 
-	tasklet_disable(&cq->cue_work);
 	spin_lock_bh(&cq->arm_lock);
 	{
 		cq->arm = 0;
 		ntrdma_dev_vbell_del(dev, &cq->vbell, cq->vbell_idx);
 	}
 	spin_unlock_bh(&cq->arm_lock);
+
+	tasklet_kill(&cq->cue_work);
 
 	mutex_lock(&dev->res_lock);
 	{

--- a/drivers/infiniband/hw/ntrdma/ntrdma_qp.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_qp.c
@@ -843,8 +843,9 @@ void ntrdma_rqp_del(struct ntrdma_rqp *rqp)
 	struct ntrdma_dev *dev = ntrdma_rqp_dev(rqp);
 
 	rqp->state = NTRDMA_QPS_RESET;
-	tasklet_disable(&rqp->send_work);
 	ntrdma_dev_vbell_del(dev, &rqp->send_vbell, rqp->send_vbell_idx);
+
+	tasklet_kill(&rqp->send_work);
 
 	ntrdma_rres_del(&rqp->rres);
 	ntrdma_debugfs_rqp_del(rqp);


### PR DESCRIPTION
Use tasklet_kill to make sure tasklet work is not scheduled.  With
tasklet_disable, a disabled tasklet may still remain scheduled on the
tasklet even list after the memory for the tasklet is free.

Signed-off-by: Allen Hubbe <Allen.Hubbe@emc.com>